### PR TITLE
update ruby devkit for 2.5

### DIFF
--- a/scripts/windows/installs/ruby_devkit.bat
+++ b/scripts/windows/installs/ruby_devkit.bat
@@ -1,7 +1,7 @@
 choco install -y ruby2.devkit
 setx PATH "%PATH%;C:\tools\DevKit2\bin"
 cd C:\tools\DevKit2
-echo "- C:\tools\ruby24" >> config.yml
-C:\tools\ruby24\bin\ruby.exe dk.rb install --force
-C:\tools\ruby24\bin\ridk.cmd install 3
+echo "- C:\tools\ruby25" >> config.yml
+C:\tools\ruby25\bin\ruby.exe dk.rb install --force
+C:\tools\ruby25\bin\ridk.cmd install 3
 refreshenv


### PR DESCRIPTION
Missed that ruby devkit relies on path to install.