### PR TITLE
lock windows bundler version to 1.17.3

### DIFF
--- a/scripts/windows/configs/prep_omnibus.bat
+++ b/scripts/windows/configs/prep_omnibus.bat
@@ -1,4 +1,4 @@
 REM Prepare ruby default gemset to handle metasploit omnibus build
 git clone https://github.com/rapid7/metasploit-omnibus
 cd metasploit-omnibus
-gem install bundler --no-ri --no-doc && bundle install --binstubs
+gem install bundler -v1.17.3 --no-ri --no-doc && bundle install --binstubs


### PR DESCRIPTION
local testing finds that bundler 2.0.1 is having issue presenting on the path in the windows build.  Locking to 1.17.3 until that can be resolved.