### PR TITLE
add requirements.txt for easier python config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+vm-automation ~= 0.1.7
+python-packer ~= 0.1.2
+tqdm


### PR DESCRIPTION
Add a `requirements.txt` to make dependency requirements simpler to install.