### PR TITLE
use visual studio express and Ruby 2.6.x

### DIFF
--- a/resources/windows/windows.json
+++ b/resources/windows/windows.json
@@ -129,7 +129,7 @@
     {
       "type":"powershell",
       "inline": [
-        "$env:chocolateyVersion = '0.10.8'; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
+        "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
       ]
     },
     {
@@ -155,7 +155,17 @@
       "scripts": [
         "scripts/windows/installs/git.bat",
         "scripts/windows/installs/mingw-64.bat",
-        "scripts/windows/installs/msys2.bat",
+        "scripts/windows/installs/msys2.bat"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "windows-shell",
+      "remote_path": "C:/Windows/Temp/script.bat",
+      "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
+      "scripts": [
         "scripts/windows/installs/java.bat",
         "scripts/windows/installs/install_ruby.bat",
         "scripts/windows/installs/ruby_devkit.bat",

--- a/resources/windows/windows.json
+++ b/resources/windows/windows.json
@@ -12,10 +12,9 @@
       "communicator": "ssh",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "ssh_wait_timeout": "2h",
+      "ssh_timeout": "2h",
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
       "guest_os_type": "{{user `vmware_guest_os_type`}}",
-      "tools_upload_flavor": "windows",
       "disk_size": 61440,
       "floppy_files": [
         "{{user `autounattend`}}",

--- a/scripts/windows/configs/prep_omnibus.bat
+++ b/scripts/windows/configs/prep_omnibus.bat
@@ -1,4 +1,4 @@
 REM Prepare ruby default gemset to handle metasploit omnibus build
 git clone https://github.com/rapid7/metasploit-omnibus
 cd metasploit-omnibus
-gem install bundler -v1.17.3 --no-ri --no-doc && bundle install --binstubs
+gem install bundler -v1.17.3 --no-document && bundle install --binstubs

--- a/scripts/windows/installs/install_ruby.bat
+++ b/scripts/windows/installs/install_ruby.bat
@@ -1,10 +1,10 @@
-choco install -y ruby --version 2.5.3.1
+choco install -y ruby --version 2.6.5.1
 refreshenv
 choco install -y ruby2.devkit
 setx PATH "%PATH%;C:\tools\DevKit2\bin"
 refreshenv
 cd C:\tools\DevKit2
-echo "- C:\tools\ruby25" >> config.yml
+echo "- C:\tools\ruby26" >> config.yml
 ruby dk.rb install --force
 ridk install 3
 refreshenv

--- a/scripts/windows/installs/msys2.bat
+++ b/scripts/windows/installs/msys2.bat
@@ -1,4 +1,3 @@
 chocolatey feature enable -n=allowGlobalConfirmation
 choco install msys2
 chocolatey feature disable -n=allowGlobalConfirmation
-shutdown -r -t 00

--- a/scripts/windows/installs/ruby_devkit.bat
+++ b/scripts/windows/installs/ruby_devkit.bat
@@ -1,7 +1,7 @@
 choco install -y ruby2.devkit
 setx PATH "%PATH%;C:\tools\DevKit2\bin"
 cd C:\tools\DevKit2
-echo "- C:\tools\ruby25" >> config.yml
-C:\tools\ruby25\bin\ruby.exe dk.rb install --force
-C:\tools\ruby25\bin\ridk.cmd install 3
+echo "- C:\tools\ruby26" >> config.yml
+C:\tools\ruby26\bin\ruby.exe dk.rb install --force
+C:\tools\ruby26\bin\ridk.cmd install 3
 refreshenv

--- a/scripts/windows/installs/vs2013.bat
+++ b/scripts/windows/installs/vs2013.bat
@@ -1,3 +1,3 @@
 chocolatey feature enable -n=allowGlobalConfirmation
-choco install visualstudiocommunity2013
+choco install visualstudioexpress2013windows
 chocolatey feature disable -n=allowGlobalConfirmation


### PR DESCRIPTION
dep_selector installation now fails in 2.5.3, updated Ruby to build gems

* Updates to Ruby 2.6.5
* Convert to building with visual studio 2013 express to reduce tool footprint
* Move reboot into packer provisioner instead of in msys2 install scirpt.
* update for Chocolatey install now requiring TLS 1.2