### PR TITLE
install a more complete VS2013 Express package

### DIFF
--- a/scripts/windows/installs/vs2013.bat
+++ b/scripts/windows/installs/vs2013.bat
@@ -1,3 +1,3 @@
 chocolatey feature enable -n=allowGlobalConfirmation
-choco install visualstudioexpress2013windows
+choco install visualstudioexpress2013windowsdesktop
 chocolatey feature disable -n=allowGlobalConfirmation


### PR DESCRIPTION
When converting to Visual Studio Express the original base install
did not bring the 7.1A SDKs, by switching to the Desktop package these
are made available in the toolset.