### PR TITLE
bump default bundler version to 2.1.4

### DIFF
--- a/resources/windows/windows.json
+++ b/resources/windows/windows.json
@@ -167,7 +167,6 @@
       "scripts": [
         "scripts/windows/installs/java.bat",
         "scripts/windows/installs/install_ruby.bat",
-        "scripts/windows/installs/ruby_devkit.bat",
         "scripts/windows/installs/wixtoolset.bat",
         "scripts/windows/installs/vs2013.bat"
       ]

--- a/scripts/windows/configs/prep_omnibus.bat
+++ b/scripts/windows/configs/prep_omnibus.bat
@@ -1,4 +1,4 @@
 REM Prepare ruby default gemset to handle metasploit omnibus build
 git clone https://github.com/rapid7/metasploit-omnibus
 cd metasploit-omnibus
-gem install bundler -v1.17.3 --no-document && bundle install --binstubs
+gem install bundler -v2.1.4 --no-document && bundle install --binstubs

--- a/scripts/windows/installs/ruby_devkit.bat
+++ b/scripts/windows/installs/ruby_devkit.bat
@@ -1,7 +1,0 @@
-choco install -y ruby2.devkit
-setx PATH "%PATH%;C:\tools\DevKit2\bin"
-cd C:\tools\DevKit2
-echo "- C:\tools\ruby26" >> config.yml
-C:\tools\ruby26\bin\ruby.exe dk.rb install --force
-C:\tools\ruby26\bin\ridk.cmd install 3
-refreshenv


### PR DESCRIPTION
Metasploit has moved to bundler 2.1.x, this updates brings that into the default windows build environment.