### PR TITLE
reorder path to put msys2 objects first

### DIFF
--- a/resources/windows/windows.json
+++ b/resources/windows/windows.json
@@ -167,6 +167,7 @@
       "scripts": [
         "scripts/windows/installs/java.bat",
         "scripts/windows/installs/install_ruby.bat",
+        "scripts/windows/installs/ruby_devkit.bat",
         "scripts/windows/installs/wixtoolset.bat",
         "scripts/windows/installs/vs2013.bat"
       ]

--- a/scripts/windows/configs/set_path.bat
+++ b/scripts/windows/configs/set_path.bat
@@ -1,1 +1,1 @@
-setx -m PATH "%PATH%;C:\PROGRA~2\WIXTOO~1.11\bin;C:\PROGRA~2\WI3CF2~1\8.1\bin\x64;C:\tools\msys64\usr\bin"
+setx -m PATH "C:\tools\msys64\usr\bin;%PATH%;C:\PROGRA~2\WIXTOO~1.11\bin;C:\PROGRA~2\WI3CF2~1\8.1\bin\x64"

--- a/scripts/windows/installs/install_ruby.bat
+++ b/scripts/windows/installs/install_ruby.bat
@@ -1,10 +1,2 @@
 choco install -y ruby --version 2.6.5.1
 refreshenv
-choco install -y ruby2.devkit
-setx PATH "%PATH%;C:\tools\DevKit2\bin"
-refreshenv
-cd C:\tools\DevKit2
-echo "- C:\tools\ruby26" >> config.yml
-ruby dk.rb install --force
-ridk install 3
-refreshenv

--- a/scripts/windows/installs/ruby_devkit.bat
+++ b/scripts/windows/installs/ruby_devkit.bat
@@ -1,0 +1,7 @@
+choco install -y ruby2.devkit
+setx PATH "%PATH%;C:\tools\DevKit2\bin"
+cd C:\tools\DevKit2
+echo "- C:\tools\ruby26" >> config.yml
+C:\tools\ruby26\bin\ruby.exe dk.rb install --force
+C:\tools\ruby26\bin\ridk.cmd install 3
+refreshenv


### PR DESCRIPTION
This places the `tar` and `xc` versions in msys64 earlier in the path.