### PR TITLE
download vs2013 directly

### DIFF
--- a/resources/windows/windows.json
+++ b/resources/windows/windows.json
@@ -168,8 +168,16 @@
         "scripts/windows/installs/java.bat",
         "scripts/windows/installs/install_ruby.bat",
         "scripts/windows/installs/ruby_devkit.bat",
-        "scripts/windows/installs/wixtoolset.bat",
-        "scripts/windows/installs/vs2013.bat"
+        "scripts/windows/installs/wixtoolset.bat"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "scripts": [
+        "scripts/windows/installs/vs2013.ps1"
       ]
     },
     {

--- a/scripts/windows/installs/vs2013.bat
+++ b/scripts/windows/installs/vs2013.bat
@@ -1,3 +1,0 @@
-chocolatey feature enable -n=allowGlobalConfirmation
-choco install visualstudioexpress2013windowsdesktop
-chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/vs2013.ps1
+++ b/scripts/windows/installs/vs2013.ps1
@@ -1,0 +1,14 @@
+(New-Object System.Net.WebClient).DownloadFile('https://msdn.hackerc.at/Visual%20Studio%202013%20Update%204/en_visual_studio_express_2013_for_windows_desktop_with_update_4_x86_dvd_5920567.iso', 'C:\Windows\Temp\vs2013express.iso')
+
+$VerifyHash = '92bf845a8520fd20639867f60def51a678d75f4e8adc7ef8e9750d04e30525bc'
+$FileHash = (Get-FileHash C:\Windows\Temp\vs2013express.iso -Algorithm SHA256).Hash
+
+if ($VerifyHash -ne $FileHash) {
+ exit -1
+}
+
+cmd /c '7z x "C:\Windows\Temp\vs2013express.iso" -oC:\Windows\Temp\VS2013'
+
+cmd /c "C:\Windows\Temp\VS2013\wdexpress_full.exe /Passive /NoRestart /Log VisualStudioExpress2013Windows.log"
+
+rm -rf C:\Windows\Temp\VS2013


### PR DESCRIPTION
Microsoft package downloads for VS2013 express has been removed
while the installer is still downloadable, this breaks the process
chocolatey install was using.  Convert to full iso download mirror
to download and install with powershell.