### PR TITLE
Update windows ruby version to 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ packer validate -var "install_pass=${INSTALL_PASS}" resources/windows/windows.pk
 packer build -var "install_pass=${INSTALL_PASS}" resources/windows/windows.pkr.hcl
 ```
 
-This will create a new AMI, and replace the existing AMI if present.
+This will create a new AMI, and replace the existing AMI if present:
+
+```
+# Replace an existing AMI. Warning - do this only if you are creating a new unused version:
+packer build -var "install_pass=${INSTALL_PASS}" -var "force_deregister=true" -var "force_delete_snapshot=true" resources/windows/windows.pkr.hcl
+```
 
 ### Debugging
 

--- a/resources/windows/windows.json
+++ b/resources/windows/windows.json
@@ -149,11 +149,11 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "remote_path": "C:/Windows/Temp/script.bat",
       "scripts": [
-        "scripts/windows/installs/install_boxstarter.bat",
-        "scripts/windows/installs/7zip.bat",
-        "scripts/windows/installs/vcredist2008.bat"
+        "scripts/windows/installs/install_boxstarter.ps1",
+        "scripts/windows/installs/7zip.ps1",
+        "scripts/windows/installs/vcredist2008.ps1"
       ],
-      "type": "windows-shell"
+      "type": "powershell"
     },
     {
       "type": "windows-restart"
@@ -162,11 +162,11 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "remote_path": "C:/Windows/Temp/script.bat",
       "scripts": [
-        "scripts/windows/installs/git.bat",
-        "scripts/windows/installs/mingw-64.bat",
-        "scripts/windows/installs/msys2.bat"
+        "scripts/windows/installs/git.ps1",
+        "scripts/windows/installs/mingw-64.ps1",
+        "scripts/windows/installs/msys2.ps1"
       ],
-      "type": "windows-shell"
+      "type": "powershell"
     },
     {
       "type": "windows-restart"
@@ -175,12 +175,12 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "remote_path": "C:/Windows/Temp/script.bat",
       "scripts": [
-        "scripts/windows/installs/java.bat",
-        "scripts/windows/installs/install_ruby.bat",
-        "scripts/windows/installs/ruby_devkit.bat",
-        "scripts/windows/installs/wixtoolset.bat"
+        "scripts/windows/installs/java.ps1",
+        "scripts/windows/installs/install_ruby.ps1",
+        "scripts/windows/installs/ruby_devkit.ps1",
+        "scripts/windows/installs/wixtoolset.ps1"
       ],
-      "type": "windows-shell"
+      "type": "powershell"
     },
     {
       "type": "windows-restart"
@@ -198,8 +198,8 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "remote_path": "C:/Windows/Temp/script.bat",
       "scripts": [
-        "scripts/windows/installs/python2.bat",
-        "scripts/windows/installs/python3.bat"
+        "scripts/windows/installs/python2.ps1",
+        "scripts/windows/installs/python3.ps1"
       ],
       "type": "windows-shell"
     },
@@ -210,7 +210,7 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "remote_path": "C:/Windows/Temp/script.bat",
       "scripts": [
-        "scripts/windows/installs/vm-guest-tools.bat",
+        "scripts/windows/installs/vm-guest-tools.ps1",
         "scripts/windows/configs/set_path.bat",
         "scripts/windows/configs/prep_omnibus.bat",
         "scripts/windows/configs/packer_cleanup.bat"

--- a/resources/windows/windows.pkr.hcl
+++ b/resources/windows/windows.pkr.hcl
@@ -7,6 +7,14 @@ packer {
   }
 }
 
+variable "force_deregister" {
+  default = false
+}
+
+variable "force_delete_snapshot" {
+  default = false
+}
+
 variable "aws_access_key" {
   type    = string
   default = "${env("AWS_ACCESS_KEY_ID")}"
@@ -50,8 +58,8 @@ variable "version" {
 }
 
 source "amazon-ebs" "win-source" {
-  force_deregister      = true
-  force_delete_snapshot = true
+  force_deregister      = "${var.force_deregister}"
+  force_delete_snapshot = "${var.force_delete_snapshot}"
   access_key     = var.aws_access_key
   communicator   = "winrm"
   instance_type  = local.instance_type

--- a/scripts/windows/configs/prep_omnibus.bat
+++ b/scripts/windows/configs/prep_omnibus.bat
@@ -1,6 +1,7 @@
 REM Prepare ruby default gemset to handle metasploit omnibus build
-git clone https://github.com/rapid7/metasploit-omnibus
+git clone https://github.com/adfoster-r7/metasploit-omnibus
 cd metasploit-omnibus
+git checkout update-support-for-ruby-3.1
 gem install bundler -v2.2.3 --no-document && bundle install && bundle binstubs --all
 cd ..
 rm -rf metasploit-omnibus

--- a/scripts/windows/configs/prep_omnibus.bat
+++ b/scripts/windows/configs/prep_omnibus.bat
@@ -1,7 +1,7 @@
 REM Prepare ruby default gemset to handle metasploit omnibus build
-git clone https://github.com/adfoster-r7/metasploit-omnibus
+git clone https://github.com/rapid7/metasploit-omnibus
 cd metasploit-omnibus
-git checkout update-support-for-ruby-3.1
+# git checkout update-support-for-ruby-3.1
 gem install bundler -v2.2.3 --no-document && bundle install && bundle binstubs --all
 cd ..
 rm -rf metasploit-omnibus

--- a/scripts/windows/installs/7zip.bat
+++ b/scripts/windows/installs/7zip.bat
@@ -1,3 +1,0 @@
-chocolatey feature enable -n=allowGlobalConfirmation
-choco install 7zip
-chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/7zip.ps1
+++ b/scripts/windows/installs/7zip.ps1
@@ -1,0 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
+chocolatey feature enable -n=allowGlobalConfirmation
+choco install 7zip
+chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/git.ps1
+++ b/scripts/windows/installs/git.ps1
@@ -1,3 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
 chocolatey feature enable -n=allowGlobalConfirmation
-choco install msys2
+choco install git
 chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/install_boxstarter.bat
+++ b/scripts/windows/installs/install_boxstarter.bat
@@ -1,3 +1,0 @@
-chocolatey feature enable -n=allowGlobalConfirmation
-choco install BoxStarter
-chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/install_boxstarter.ps1
+++ b/scripts/windows/installs/install_boxstarter.ps1
@@ -1,3 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
 chocolatey feature enable -n=allowGlobalConfirmation
-choco install git
+choco install BoxStarter
 chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/install_netfx.ps1
+++ b/scripts/windows/installs/install_netfx.ps1
@@ -1,3 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
 # setup dotnetfx4
 $netfx_url = "https://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe"
 

--- a/scripts/windows/installs/install_ruby.bat
+++ b/scripts/windows/installs/install_ruby.bat
@@ -1,2 +1,0 @@
-choco install -y ruby --version 2.6.5.1
-refreshenv

--- a/scripts/windows/installs/install_ruby.ps1
+++ b/scripts/windows/installs/install_ruby.ps1
@@ -1,0 +1,5 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
+choco install -y ruby --version 3.0.5.1
+refreshenv

--- a/scripts/windows/installs/java.ps1
+++ b/scripts/windows/installs/java.ps1
@@ -1,0 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
+chocolatey feature enable -n=allowGlobalConfirmation
+choco install jre8 --version 8.0.151
+chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/mingw-64.ps1
+++ b/scripts/windows/installs/mingw-64.ps1
@@ -1,0 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
+chocolatey feature enable -n=allowGlobalConfirmation
+choco install mingw
+chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/msys2.ps1
+++ b/scripts/windows/installs/msys2.ps1
@@ -1,3 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
 chocolatey feature enable -n=allowGlobalConfirmation
-choco install mingw
+choco install msys2
 chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/openssh.ps1
+++ b/scripts/windows/installs/openssh.ps1
@@ -2,6 +2,9 @@ param (
   [switch]$AutoStart = $false
 )
 
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
 Write-Output "AutoStart: $AutoStart"
 $is_64bit = [IntPtr]::size -eq 8
 

--- a/scripts/windows/installs/python2.ps1
+++ b/scripts/windows/installs/python2.ps1
@@ -1,3 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
 chocolatey feature enable -n=allowGlobalConfirmation
 set ChocolateyUrlOverride=https://baseline-builder.s3.amazonaws.com/python-2.7.11.msi
 set ChocolateyUrl64bitOverride=https://baseline-builder.s3.amazonaws.com/python-2.7.11.amd64.msi

--- a/scripts/windows/installs/python3.ps1
+++ b/scripts/windows/installs/python3.ps1
@@ -1,3 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
 chocolatey feature enable -n=allowGlobalConfirmation
-choco install wixtoolset
+choco install python --version 3.4.4.20180111
 chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/ruby_devkit.bat
+++ b/scripts/windows/installs/ruby_devkit.bat
@@ -1,6 +1,0 @@
-cd C:\vagrant\resources\windows\ruby_devkit_runtime
-tar -cvf ../ruby_devkit_runtime.tar .
-cd ..
-tar -C C:\tools\ruby26\lib\ruby\site_ruby\2.6.0 -xvf ruby_devkit_runtime.tar
-C:\tools\ruby26\bin\ridk.cmd install 3
-refreshenv

--- a/scripts/windows/installs/ruby_devkit.ps1
+++ b/scripts/windows/installs/ruby_devkit.ps1
@@ -1,0 +1,10 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
+cd C:\vagrant\resources\windows\ruby_devkit_runtime
+tar -cvf ../ruby_devkit_runtime.tar .
+cd ..
+tar -C C:\tools\ruby30\lib\ruby\site_ruby\3.0.0 -xvf ruby_devkit_runtime.tar
+# Install option 3 - the msys2 and mingw development toolchain
+C:\tools\ruby30\bin\ridk.cmd install 3
+refreshenv

--- a/scripts/windows/installs/vcredist2008.bat
+++ b/scripts/windows/installs/vcredist2008.bat
@@ -1,3 +1,0 @@
-chocolatey feature enable -n=allowGlobalConfirmation
-choco install vcredist2008
-chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/vcredist2008.ps1
+++ b/scripts/windows/installs/vcredist2008.ps1
@@ -1,3 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
 chocolatey feature enable -n=allowGlobalConfirmation
-choco install python --version 3.4.4.20180111
+choco install vcredist2008
 chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/vm-guest-tools.ps1
+++ b/scripts/windows/installs/vm-guest-tools.ps1
@@ -1,3 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
 if not exist "C:\Program Files\7-Zip\7z.exe" (
     powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (New-Object System.Net.WebClient).DownloadFile('https://www.7-zip.org/a/7z1604-x64.msi', 'C:\Windows\Temp\7zInstaller-x64.msi')" <NUL
     msiexec /qb /i C:\Windows\Temp\7zInstaller-x64.msi

--- a/scripts/windows/installs/wixtoolset.ps1
+++ b/scripts/windows/installs/wixtoolset.ps1
@@ -1,3 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
 chocolatey feature enable -n=allowGlobalConfirmation
-choco install jre8 --version 8.0.151
+choco install wixtoolset
 chocolatey feature disable -n=allowGlobalConfirmation

--- a/templates/metasploitMacOSBuilder.json
+++ b/templates/metasploitMacOSBuilder.json
@@ -9,5 +9,5 @@
   "vagrantfile_template": "vagrant/vagrantfile-metasploitMacOSBuilder.tpl",
   "virtualbox_guest_os_type": "MacOS1015_64",
   "vmware_guest_os_type": "darwin18-64",
-  "version": "1.0.7"
+  "version": "1.0.8"
 }

--- a/templates/metasploitWindowsBuilder.json
+++ b/templates/metasploitWindowsBuilder.json
@@ -8,5 +8,5 @@
   "virtualbox_guest_os_type": "Windows10_64",
   "vm_name": "metasploitWindowsBuilder",
   "os_key": "W269N-WFGWX-YVC9B-4J6C9-T83GX",
-  "version": "1.0.7"
+  "version": "1.0.8"
 }


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-vagrant-builders/pull/18

Updating to compile Ruby 3.0 on the Windows builder machine