### PR TITLE
Update macos to Ruby 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.8
+
+- Update OSX to 11.7.10; Compile Ruby 3.0.6
+- Update Windows to Compile Ruby 3.0.6

--- a/resources/macos/macos.json
+++ b/resources/macos/macos.json
@@ -28,7 +28,7 @@
   ],
   "provisioners": [
     {
-      "destination": "/private/tmp/Install_macOS_11.7.4-20G1120.dmg",
+      "destination": "/private/tmp/Install_macOS_11.7.10.dmg",
       "source": "{{user `iso_url`}}",
       "type": "file"
     },

--- a/scripts/macos/cleanup_upgrade_installer.sh
+++ b/scripts/macos/cleanup_upgrade_installer.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # TODO: refactor the file name to be an ENV variable
-rm /private/tmp/Install_macOS_11.7.4-20G1120.dmg
+rm -f /private/tmp/Install_macOS_11.7.10.dmg

--- a/scripts/macos/install_macos_upgrade.sh
+++ b/scripts/macos/install_macos_upgrade.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-open /private/tmp/Install_macOS_11.7.4-20G1120.dmg
+open /private/tmp/Install_macOS_11.7.10.dmg
 until [ -d /Volumes/Install\ macOS\ Big\ Sur ]
 do
   sleep 5

--- a/scripts/macos/install_rvm_req.sh
+++ b/scripts/macos/install_rvm_req.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 
-su vagrant -c 'gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB'
-su vagrant -c '\curl -sSL https://get.rvm.io | bash -s stable --ruby'
+set -euxo pipefail
 
-su vagrant -c '/bin/bash -l -c "rvm install 2.5.3"'
-su vagrant -c '/bin/bash -l -c "rvm use 2.5.3; gem install bundler -v2.1.4"'
+su vagrant -c 'export PATH="$(/usr/local/Homebrew/bin/brew --prefix gpg)/bin:$PATH"; export PATH="$(/usr/local/Homebrew/bin/brew --prefix coreutils)/bin:$PATH"; which gpg; which sha256sum; curl -o mpapis.asc -sSL https://rvm.io/mpapis.asc && echo "08f64631c598cbe4398c5850725c8e6ab60dc5d86b6214e069d7ced1d546043b  mpapis.asc" | sha256sum -c && gpg --import ./mpapis.asc; rm mpapis.asc'
+su vagrant -c 'export PATH="$(/usr/local/Homebrew/bin/brew --prefix gpg)/bin:$PATH"; export PATH="$(/usr/local/Homebrew/bin/brew --prefix coreutils)/bin:$PATH"; which gpg; which sha256sum; curl -o pkuczynski.asc -sSL https://rvm.io/pkuczynski.asc && echo "d33ce5907fe28e6938feab7f63a9ef8a26a565878b1ad5bce063a86019aeaf77  pkuczynski.asc" | sha256sum -c && gpg --import ./pkuczynski.asc; rm pkuczynski.asc'
+su vagrant -c 'export PATH="$(/usr/local/Homebrew/bin/brew --prefix gpg)/bin:$PATH"; \curl -sSL https://get.rvm.io | bash -s stable'
+
+# For now build Ruby 3.0 with OpenSSL@1.1; it can be bumped to OpenSSL@3.x for Ruby 3.1+
+rvm_install='
+set -x
+export PATH="$(brew --prefix openssl@1.1)/bin:$PATH";
+export LDFLAGS="-L$(brew --prefix openssl@1.1)/lib";
+export CPPFLAGS="-I$(brew --prefix openssl@1.1)/include";
+export PKG_CONFIG_PATH="$(brew --prefix openssl@1.1)/lib/pkgconfig";
+set +x
+rvm reinstall 3.0.6
+'
+su vagrant -c "/bin/bash -l -c '$rvm_install'"
+su vagrant -c '/bin/bash -l -c "rvm use 3.0.6; gem install bundler -v2.2.3"'

--- a/templates/metasploitMacOSBuilder.json
+++ b/templates/metasploitMacOSBuilder.json
@@ -4,7 +4,7 @@
   "cpus": "2",
   "disk_size": "32000",
   "memory": "2048",
-  "iso_url": "iso/Install_macOS_11.7.4-20G1120.dmg",
+  "iso_url": "iso/Install_macOS_11.7.10.dmg",
   "parallels_guest_os_type": "win-8",
   "vagrantfile_template": "vagrant/vagrantfile-metasploitMacOSBuilder.tpl",
   "virtualbox_guest_os_type": "MacOS1015_64",


### PR DESCRIPTION
We need to rebuild the OSX builder to support Ruby 3.0, as we need a newer RVM version etc.

Paper trail for windows:
- https://github.com/rapid7/metasploit-vagrant-builders/pull/19
- https://github.com/rapid7/metasploit-vagrant-builders/pull/18
- https://github.com/rapid7/metasploit-vagrant-builders/pull/20