### PR TITLE
Add in vs2013 and cmake alongside vs2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 1.0.10
+
+- Install Visual Studio 2013 alongside 2019
+- Install cmake
+
 ## 1.0.9
 
-- Update Visual Studio 2013 to 2019; Compile Nmap 7.95
+- Update Visual Studio 2013 to 2019
 - Update Ruby on Windows to 3.0.7 (Security Patch)
 
 ## 1.0.8

--- a/resources/windows/windows.json
+++ b/resources/windows/windows.json
@@ -150,7 +150,8 @@
       "scripts": [
         "scripts/windows/installs/install_boxstarter.ps1",
         "scripts/windows/installs/7zip.ps1",
-        "scripts/windows/installs/vcredist2008.ps1"
+        "scripts/windows/installs/vcredist2008.ps1",
+        "scripts/windows/installs/cmake.ps1"
       ],
       "type": "powershell"
     },
@@ -187,6 +188,15 @@
     {
       "scripts": [
         "scripts/windows/installs/vs2019.ps1"
+      ],
+      "type": "powershell"
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "scripts": [
+        "scripts/windows/installs/vs2013.ps1"
       ],
       "type": "powershell"
     },

--- a/resources/windows/windows.pkr.hcl
+++ b/resources/windows/windows.pkr.hcl
@@ -243,8 +243,8 @@ build {
     scripts           = ["scripts/windows/installs/vs2013.ps1"]
   }
 
-provisioner "windows-restart" {
-}
+  provisioner "windows-restart" {
+  }
 
   provisioner "powershell" {
     elevated_user     = var.install_user

--- a/resources/windows/windows.pkr.hcl
+++ b/resources/windows/windows.pkr.hcl
@@ -54,7 +54,7 @@ EOF
 
 variable "version" {
   type = string
-  default = "1.0.9"
+  default = "1.0.10"
 }
 
 variable "authorized_keys_path" {
@@ -187,7 +187,8 @@ build {
     elevated_password = var.install_pass
     scripts           = ["scripts/windows/installs/install_boxstarter.ps1",
                          "scripts/windows/installs/7zip.ps1",
-                         "scripts/windows/installs/vcredist2008.ps1"]
+                         "scripts/windows/installs/vcredist2008.ps1",
+                         "scripts/windows/installs/cmake.ps1"]
   }
 
   provisioner "windows-restart" {
@@ -235,6 +236,15 @@ build {
 
   provisioner "windows-restart" {
   }
+
+  provisioner "powershell" {
+    elevated_user     = var.install_user
+    elevated_password = var.install_pass
+    scripts           = ["scripts/windows/installs/vs2013.ps1"]
+  }
+
+provisioner "windows-restart" {
+}
 
   provisioner "powershell" {
     elevated_user     = var.install_user

--- a/scripts/windows/installs/cmake.ps1
+++ b/scripts/windows/installs/cmake.ps1
@@ -1,0 +1,6 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
+chocolatey feature enable -n=allowGlobalConfirmation
+choco install cmake --installargs '"ADD_CMAKE_TO_PATH=System"'
+chocolatey feature disable -n=allowGlobalConfirmation

--- a/scripts/windows/installs/vs2013.ps1
+++ b/scripts/windows/installs/vs2013.ps1
@@ -1,0 +1,32 @@
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
+$Logfile = "C:\Windows\Temp\vs2013-updates.log"
+
+function LogWrite {
+   Param ([string]$logstring)
+   $now = Get-Date -format s
+   Add-Content $Logfile -value "$now $logstring"
+   Write-Host $logstring
+}
+
+LogWrite "Downloading visual studio (Can take 30 minutes or more)"
+[Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
+(New-Object System.Net.WebClient).DownloadFile('https://archive.org/download/msdn_2023/en_visual_studio_express_2013_for_windows_desktop_with_update_4_x86_dvd_5920567.iso', 'C:\Windows\Temp\vs2013express.iso')
+LogWrite "Finished downloading visual studio"
+
+$VerifyHash = '92bf845a8520fd20639867f60def51a678d75f4e8adc7ef8e9750d04e30525bc'
+$FileHash = (Get-FileHash C:\Windows\Temp\vs2013express.iso -Algorithm SHA256).Hash
+
+if ($VerifyHash -ne $FileHash) {
+ exit -1
+}
+
+LogWrite "Extracting visual studio"
+cmd /c '7z x "C:\Windows\Temp\vs2013express.iso" -oC:\Windows\Temp\VS2013'
+
+LogWrite "Installing visual studio"
+cmd /c "C:\Windows\Temp\VS2013\wdexpress_full.exe /Passive /NoRestart /Log VisualStudioExpress2013Windows.log"
+
+LogWrite "Removing visual studio temp files"
+Remove-Item -Recurse -Force -ErrorAction SilentlyContinue "C:\Windows\Temp\VS2013"

--- a/templates/metasploitWindowsBuilder.json
+++ b/templates/metasploitWindowsBuilder.json
@@ -8,6 +8,6 @@
   "virtualbox_guest_os_type": "Windows10_64",
   "vm_name": "metasploitWindowsBuilder",
   "os_key": "W269N-WFGWX-YVC9B-4J6C9-T83GX",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "authorized_keys_path": "resources/authorized_keys"
 }


### PR DESCRIPTION
Turns out building nmap with vs2019 isn't currently viable, but we will need to make that change sometime in the future. For now putting vs2013 back on the box alongside vs2019 so we can move components over one by one without needing to rebuild the AMI

The reason for cmake is that nmap 7.95 needs it and while vs2019 has cmake available to it vs2013 does not so we install it separately so we can use it as part of the nmap build

https://github.com/rapid7/metasploit-vagrant-builders/pull/23
https://github.com/rapid7/metasploit-jenkins-jobs/pull/509
https://github.com/rapid7/pro/pull/3661