### PR TITLE
Bump Windows version, add long path support

### DIFF
--- a/resources/windows/windows.json
+++ b/resources/windows/windows.json
@@ -120,6 +120,7 @@
       "execute_command": "{{.Vars}} cmd /c C:/Windows/Temp/script.bat",
       "remote_path": "/tmp/script.bat",
       "scripts": [
+        "./scripts/windows/configs/enable-long-paths.bat",
         "./scripts/windows/configs/update_root_certs.bat",
         "./scripts/windows/configs/disable-auto-logon.bat",
         "./scripts/windows/configs/disable-firewall.bat",

--- a/resources/windows/windows.pkr.hcl
+++ b/resources/windows/windows.pkr.hcl
@@ -158,7 +158,8 @@ build {
   provisioner "powershell" {
     elevated_user     = var.install_user
     elevated_password = var.install_pass
-    scripts           = ["./scripts/windows/configs/update_root_certs.bat",
+    scripts           = ["./scripts/windows/configs/enable-long-paths.bat",
+                         "./scripts/windows/configs/update_root_certs.bat",
                          "./scripts/windows/configs/disable-auto-logon.bat",
                          "./scripts/windows/configs/disable-firewall.bat",
                          "./scripts/windows/configs/enable-rdp.bat",

--- a/scripts/windows/configs/enable-long-paths.bat
+++ b/scripts/windows/configs/enable-long-paths.bat
@@ -1,0 +1,1 @@
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f

--- a/templates/metasploitWindowsBuilder.json
+++ b/templates/metasploitWindowsBuilder.json
@@ -1,6 +1,6 @@
 {
-  "iso_url": "./iso/en_windows_10_consumer_editions_version_1803_updated_march_2018_x64_dvd_12063379.iso",
-  "iso_checksum": "986e2e17cf6b0b49141cd15699768e6e",
+  "iso_url": "./iso/en-us_windows_10_consumer_editions_version_21h2_x64_dvd_6cfdb144.iso",
+  "iso_checksum": "823c3cb59ff0fd43272f12bb2e3a089d",
   "iso_checksum_type": "md5",
   "autounattend": "./resources/windows/answer_files/Autounattend.xml",
   "vagrantfile_template": "./vagrant/vagrantfile-metasploitWindowsBuilder.tpl",
@@ -8,6 +8,6 @@
   "virtualbox_guest_os_type": "Windows10_64",
   "vm_name": "metasploitWindowsBuilder",
   "os_key": "W269N-WFGWX-YVC9B-4J6C9-T83GX",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "authorized_keys_path": "resources/authorized_keys"
 }


### PR DESCRIPTION
This PR:
- bumps the Windows version
- bumps the ISO used by Windows
- adds long path support to ensure we don't hit path length limits when e.g. compiling things.